### PR TITLE
boto just added / winrm version locked

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,15 @@ RUN apk add --update \
 	&& rm -rf /var/cache/apk/*
 
 ENV ANSIBLE_VERSION 2.2.1.0
-ENV WINRM_MIN_VERSION 0.2.0
+ENV BOTO_VERSION 2.46.1
+ENV WINRM_VERSION 0.2.2
 ENV KERBEROS_VERSION 1.2.2
 
 RUN 	pip install --upgrade pip && \
 	pip install "ansible==$ANSIBLE_VERSION" --no-binary :all: && \
-	pip install "pywinrm>=$WINRM_MIN_VERSION" && \
-	pip install "kerberos==$KERBEROS_VERSION" 
+	pip install "boto==$BOTO_VERSION" && \
+	pip install "pywinrm==$WINRM_VERSION" && \
+	pip install "kerberos==$KERBEROS_VERSION"
 
 VOLUME /work
 WORKDIR /work


### PR DESCRIPTION
When I was trying to deploy a CloudFormation stack into AWS it was required to have boto installed.
So it was set to the most updated version that works with this Ansible version.

Also, the winrm version was locked into the most updated version. Personally I consider this important, so there is no chance of some unpredictable behavior related to new versions from this library.